### PR TITLE
Fix packets per frame setting

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -79,6 +79,9 @@ class CameraApp:
                                         command=self.on_volume_change)
         self.volume_slider.grid(row=0, column=9, padx=5)
 
+        self.packets_label = ttk.Label(controls, text="Pkts: 0")
+        self.packets_label.grid(row=0, column=10, padx=5)
+
     # ----------------- STREAM CONTROL -----------------
     def toggle_stream(self):
         if not self.streamer.running:
@@ -97,6 +100,7 @@ class CameraApp:
     # ----------------- FRAME HANDLING -----------------
     def _on_frame(self, img):
         self.current_frame = img
+        self.packets_label.config(text=f"Pkts: {self.streamer.packets_in_frame()}")
         if self.recording and self.video_writer:
             frame = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
             self.video_writer.write(frame)

--- a/streamer.py
+++ b/streamer.py
@@ -62,6 +62,9 @@ class CameraStreamer:
         self.receiver_thread = threading.Thread(target=self._recv_frames, daemon=True)
         self.keepalive_thread.start()
         self.receiver_thread.start()
+        # reset counters for consistent behaviour after restarts
+        self.current_packet_count = 0
+        self.last_packet_count = 0
 
     def stop(self):
         self.running = False
@@ -77,6 +80,8 @@ class CameraStreamer:
                 self.keepalive_sock = None
         self.jpeg_buffer.clear()
         self.last_frame_time = 0.0
+        self.current_packet_count = 0
+        self.last_packet_count = 0
 
     def _send_keepalive(self):
         payload_8070 = b"0f"


### PR DESCRIPTION
## Summary
- reset packet counters when restarting the stream
- show packets used for last frame in GUI

## Testing
- `python -m py_compile config.py config_dialog.py gui.py main.py streamer.py`

------
https://chatgpt.com/codex/tasks/task_e_68443278c1108326904a7c8d01756fa7