### PR TITLE
Add frame alignment check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The preview canvas keeps a 1:1 aspect ratio and shows a message if the stream
 is not running.
 The config also allows setting **Packets per Frame** which controls how many
 network packets are collected before a JPEG frame is processed.
+An additional slider on the main window sets the **Alignment Threshold** for
+checking horizontal drift between frames.
 Run with:
 ```bash
 pip install -r requirements.txt

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ class StreamConfig:
     jitter_delay: int = 0
     packets_per_frame: int = 1
     keepalive_interval: float = 0.0
+    alignment_threshold: int = 20
 
     def save(self, path: str = CONFIG_PATH) -> None:
         with open(path, "w", encoding="utf-8") as fh:

--- a/config_dialog.py
+++ b/config_dialog.py
@@ -31,6 +31,7 @@ class ConfigDialog(tk.Toplevel):
             ("Jitter Delay", "jitter_delay"),
             ("Packets per Frame", "packets_per_frame"),
             ("Keepalive Interval", "keepalive_interval"),
+            ("Alignment Threshold", "alignment_threshold"),
         ]
 
         frame = ttk.Frame(self)


### PR DESCRIPTION
## Summary
- store `alignment_threshold` in config
- expose the threshold in settings dialog
- add slider on main window to adjust threshold
- compute difference between frame packets to detect drift
- show difference value with color feedback
- document alignment slider in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68448c3a2eac8326a88b7d28ff2a35b0