### PR TITLE
Fix streamer and config dialog

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,6 @@ class StreamConfig:
     jitter_delay: int = 0
     packets_per_frame: int = 1
     keepalive_interval: float = 0.0
-    alignment_threshold: int = 20
     frame_width: int = 640
     frame_height: int = 480
     channels: int = 3

--- a/config_dialog.py
+++ b/config_dialog.py
@@ -31,7 +31,6 @@ class ConfigDialog(tk.Toplevel):
             ("Jitter Delay", "jitter_delay"),
             ("Packets per Frame", "packets_per_frame"),
             ("Keepalive Interval", "keepalive_interval"),
-            ("Alignment Threshold", "alignment_threshold"),
         ]
 
         frame = ttk.Frame(self)
@@ -84,7 +83,11 @@ class ConfigDialog(tk.Toplevel):
                 continue
             current_value = getattr(self._config, field)
             cast_type = type(current_value)
-            setattr(self._config, field, cast_type(var.get()))
+            val = var.get()
+            try:
+                setattr(self._config, field, cast_type(val))
+            except ValueError:
+                setattr(self._config, field, current_value)
         self._config.save()
         if self._on_save:
             self._on_save()

--- a/gui.py
+++ b/gui.py
@@ -295,8 +295,6 @@ class CameraApp:
         # Placeholder for real volume control
         pass
 
-    def on_align_change(self, _=None):
-        self.config.alignment_threshold = int(float(self.align_threshold.get()))
 
     def open_config_dialog(self) -> None:
         ConfigDialog(self.root, self.config, on_save=self._on_config_saved)
@@ -308,4 +306,3 @@ class CameraApp:
         self.streamer = CameraStreamer(self.config, self.processor)
         if was_running:
             self.streamer.start(self.frame_queue)
-        self.align_threshold.set(self.config.alignment_threshold)

--- a/streamer.py
+++ b/streamer.py
@@ -157,6 +157,38 @@ class CameraStreamer:
                 time.sleep(self.config.jitter_delay / 1000.0)
             self._frame_buffer.reset()
 
+
+def start_dummy_camera(config: StreamConfig, frame: Image.Image, count: int = 1) -> threading.Thread:
+    """Send `count` frames to the client using the same packet format as the real camera."""
+
+    def _run() -> None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # send from the configured camera port
+        try:
+            sock.bind((config.cam_ip, config.cam_video_port))
+        except Exception:
+            sock.bind((config.cam_ip, 0))
+        payload = np.array(frame, dtype=np.uint8).tobytes()
+        for _ in range(count):
+            for seq in range(config.num_chunks):
+                start = seq * config.chunk_size
+                end = start + config.chunk_size
+                chunk = payload[start:end]
+                crc = binascii.crc_hqx(chunk, 0xFFFF)
+                pkt = (
+                    seq.to_bytes(3, "big")
+                    + crc.to_bytes(2, "big")
+                    + bytes(config.header_bytes - 5)
+                    + chunk
+                )
+                sock.sendto(pkt, ("127.0.0.1", config.client_video_port))
+            time.sleep(0.05)
+        sock.close()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    return t
+
     def _extract_frames(self) -> None:
         """Parse buffered JPEG data into frames and dispatch them."""
         while True:

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import queue
+import time
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from config import StreamConfig
+from streamer import FrameProcessor, CameraStreamer, start_dummy_camera
+
+
+def test_streamer_receives_frame():
+    config = StreamConfig(
+        cam_ip="127.0.0.1",
+        cam_video_port=9000,
+        client_video_port=9001,
+        frame_width=32,
+        frame_height=32,
+        channels=3,
+        rows_per_chunk=16,
+    )
+
+    processor = FrameProcessor()
+    streamer = CameraStreamer(config, processor)
+    q = queue.Queue()
+    streamer.start(q)
+
+    img = Image.new("RGB", (config.frame_width, config.frame_height), "blue")
+    sender = start_dummy_camera(config, img)
+    try:
+        received = False
+        for _ in range(30):
+            try:
+                frame = q.get_nowait()
+                received = True
+                assert frame.size == img.size
+                break
+            except queue.Empty:
+                time.sleep(0.1)
+        assert received, "no frame received"
+    finally:
+        streamer.stop()
+        sender.join(timeout=1)
+


### PR DESCRIPTION
## Summary
- remove obsolete alignment threshold option
- handle invalid config values gracefully
- add dummy camera utility for tests
- test streaming with dummy frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449e6ed06c8326ad0b7e91dcfce741