### PR TITLE
Add verbose mode and improve streaming test

### DIFF
--- a/config_dialog.py
+++ b/config_dialog.py
@@ -26,6 +26,8 @@ class ConfigDialog(tk.Toplevel):
             ("Cam Audio Port", "cam_audio_port"),
             ("Client Video Port", "client_video_port"),
             ("Client Audio Port", "client_audio_port"),
+            ("Frame Width", "frame_width"),
+            ("Frame Height", "frame_height"),
             ("Frame Buffer", "frame_buffer_size"),
             ("Header Bytes", "header_bytes"),
             ("Jitter Delay", "jitter_delay"),

--- a/gui.py
+++ b/gui.py
@@ -2,6 +2,7 @@ import os
 import time
 import subprocess
 import shutil
+import logging
 import tkinter as tk
 from tkinter import ttk, messagebox
 import queue
@@ -128,10 +129,13 @@ class CameraApp:
     # ----------------- STREAM CONTROL -----------------
     def toggle_stream(self):
         if not self.streamer.running:
+            logging.info("starting stream")
             self.streamer.start(self.frame_queue)
+            self.streamer.check_connection()
             self.stream_btn.config(text="Stop Stream")
             self.record_btn.config(state="normal")
         else:
+            logging.info("stopping stream")
             if self.recording:
                 self.toggle_record()
             self.streamer.stop()
@@ -144,6 +148,7 @@ class CameraApp:
 
     # ----------------- FRAME HANDLING -----------------
     def _handle_frame(self, img):
+        logging.debug("frame received")
         self.packets_label.config(text=f"Pkts: {self.streamer.packets_in_frame()}")
         aligned, offset = self._align_frame(self.prev_frame, img)
         self.prev_frame = aligned.copy()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,25 @@
+import argparse
+import logging
 import tkinter as tk
 from gui import CameraApp
 
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="AP Camera Receiver")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose logging",
+    )
+    return parser.parse_args()
+
 if __name__ == "__main__":
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
     root = tk.Tk()
     app = CameraApp(root)
     root.mainloop()


### PR DESCRIPTION
## Summary
- add command line parser with `--verbose`
- extend config dialog for frame dimensions
- implement logging and connection checks in `CameraStreamer`
- update dummy camera to send JPEG data over UDP
- adjust GUI to use logging when starting/stopping streams
- expand streaming test to use new dummy camera

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f4547eb08326bc69ac3da083f23f