### PR TITLE
Add video controls and robust streaming

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,13 @@ class StreamConfig:
     packets_per_frame: int = 1
     keepalive_interval: float = 0.0
     alignment_threshold: int = 20
+    display_width: int = 640
+    display_height: int = 480
+    brightness: float = 1.0
+    contrast: float = 1.0
+    saturation: float = 1.0
+    hue: float = 0.0
+    gamma: float = 1.0
 
     def save(self, path: str = CONFIG_PATH) -> None:
         with open(path, "w", encoding="utf-8") as fh:

--- a/config_dialog.py
+++ b/config_dialog.py
@@ -20,7 +20,16 @@ class ConfigDialog(tk.Toplevel):
         self._build()
 
     def _build(self) -> None:
-        fields = [
+        """Construct the configuration notebook with stream and video tabs."""
+        nb = ttk.Notebook(self)
+        nb.pack(padx=10, pady=10, fill="both", expand=True)
+
+        stream_frame = ttk.Frame(nb)
+        video_frame = ttk.Frame(nb)
+        nb.add(stream_frame, text="Stream")
+        nb.add(video_frame, text="Video")
+
+        stream_fields = [
             ("Camera IP", "cam_ip"),
             ("Cam Video Port", "cam_video_port"),
             ("Cam Audio Port", "cam_audio_port"),
@@ -34,45 +43,57 @@ class ConfigDialog(tk.Toplevel):
             ("Alignment Threshold", "alignment_threshold"),
         ]
 
-        frame = ttk.Frame(self)
-        frame.pack(padx=10, pady=10)
+        video_fields = [
+            ("Width", "display_width"),
+            ("Height", "display_height"),
+            ("Brightness", "brightness"),
+            ("Contrast", "contrast"),
+            ("Saturation", "saturation"),
+            ("Hue", "hue"),
+            ("Gamma", "gamma"),
+        ]
 
         buffer_values = [2 ** i for i in range(10, 31)]
 
-        for i, (label, field) in enumerate(fields):
-            ttk.Label(frame, text=label).grid(row=i, column=0, sticky="w")
-            value = getattr(self._config, field)
-            if field == "frame_buffer_size":
-                idx = buffer_values.index(value) if value in buffer_values else 0
-                var = tk.IntVar(value=buffer_values[idx])
-                self._vars[field] = var
-                label_var = tk.StringVar(value=str(var.get()))
+        def add_fields(frame: ttk.Frame, fields: list[tuple[str, str]]):
+            for i, (label, field) in enumerate(fields):
+                ttk.Label(frame, text=label).grid(row=i, column=0, sticky="w")
+                value = getattr(self._config, field)
+                if field == "frame_buffer_size":
+                    idx = buffer_values.index(value) if value in buffer_values else 0
+                    var = tk.IntVar(value=buffer_values[idx])
+                    self._vars[field] = var
+                    label_var = tk.StringVar(value=str(var.get()))
 
-                def update(val, v=var, l=label_var):
-                    choice = buffer_values[int(float(val))]
-                    v.set(choice)
-                    l.set(str(choice))
+                    def update(val, v=var, l=label_var):
+                        choice = buffer_values[int(float(val))]
+                        v.set(choice)
+                        l.set(str(choice))
 
-                scale = tk.Scale(
-                    frame,
-                    from_=0,
-                    to=len(buffer_values) - 1,
-                    orient="horizontal",
-                    showvalue=False,
-                    command=update,
-                )
-                scale.set(idx)
-                scale.grid(row=i, column=1, padx=5, pady=2)
-                ttk.Label(frame, textvariable=label_var).grid(row=i, column=2, sticky="w")
-                self._vars[field + "_label"] = label_var
-                self._vars[field + "_scale"] = scale
-            else:
-                var = tk.StringVar(value=str(value))
-                self._vars[field] = var
-                ttk.Entry(frame, textvariable=var, width=15).grid(row=i, column=1, padx=5, pady=2)
+                    scale = tk.Scale(
+                        frame,
+                        from_=0,
+                        to=len(buffer_values) - 1,
+                        orient="horizontal",
+                        showvalue=False,
+                        command=update,
+                    )
+                    scale.set(idx)
+                    scale.grid(row=i, column=1, padx=5, pady=2)
+                    ttk.Label(frame, textvariable=label_var).grid(row=i, column=2, sticky="w")
+                    self._vars[field + "_label"] = label_var
+                    self._vars[field + "_scale"] = scale
+                else:
+                    var_cls = tk.DoubleVar if isinstance(value, float) else tk.IntVar
+                    var = var_cls(value=value)
+                    self._vars[field] = var
+                    ttk.Entry(frame, textvariable=var, width=15).grid(row=i, column=1, padx=5, pady=2)
 
-        btn_frame = ttk.Frame(frame)
-        btn_frame.grid(row=len(fields), column=0, columnspan=2, pady=5)
+        add_fields(stream_frame, stream_fields)
+        add_fields(video_frame, video_fields)
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack(pady=5)
 
         ttk.Button(btn_frame, text="Save", command=self._save).pack(side="left", padx=5)
         ttk.Button(btn_frame, text="Restore Defaults", command=self._restore_defaults).pack(side="left", padx=5)
@@ -95,7 +116,8 @@ class ConfigDialog(tk.Toplevel):
         for field, var in self._vars.items():
             if field.endswith("_label") or field.endswith("_scale"):
                 continue
-            var.set(str(getattr(defaults, field)))
+            value = getattr(defaults, field)
+            var.set(value)
             if field == "frame_buffer_size":
                 label = self._vars.get(field + "_label")
                 scale = self._vars.get(field + "_scale")

--- a/main.py
+++ b/main.py
@@ -1,7 +1,18 @@
+import argparse
+import logging
 import tkinter as tk
 from gui import CameraApp
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="AP Camera Receiver")
+    parser.add_argument("--verbose", action="store_true", help="enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
     root = tk.Tk()
     app = CameraApp(root)
     root.mainloop()


### PR DESCRIPTION
## Summary
- add display and color settings to `StreamConfig`
- implement two-tab settings dialog with video options
- extend `FrameProcessor` with brightness, contrast, etc.
- queue frames and dispatch with logging in `CameraStreamer`
- render frames safely and handle huge window sizes
- add command line `--verbose` flag for debug output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --verbose` *(fails: no $DISPLAY variable)*

------
https://chatgpt.com/codex/tasks/task_e_684500d61da483268805bfadf2c5237f